### PR TITLE
Fixed path handling on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 
 module.exports = function(options) {
     options = typeof options == 'string' ? {src:options} : (options || {})
-    var src = options.src
+    var src = path.normalize(options.src)
     var watch = !options.cache
     var cache = {}
     var watchCallback = options.watchCallback


### PR DESCRIPTION
Since we're normalize actual request path but not `options.src`, it have wrong slashes and security check

```
if (stylusPath.indexOf(src) !== 0) {
```

will fail.
