### PR TITLE
Don't require express's convenience method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function(options) {
                 }
                 return next(error)
             }
-            response.setHeader('Content-type', 'text/css')
+            response.setHeader('content-type', 'text/css')
             response.send(css)
         })
     }

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function(options) {
                 }
                 return next(error)
             }
-            response.header('Content-type', 'text/css')
+            response.setHeader('Content-type', 'text/css')
             response.send(css)
         })
     }


### PR DESCRIPTION
`response.header` is a convenience method added by express.js that internally calls `response.setHeader` (https://github.com/strongloop/express/blob/master/lib/response.js#L692). This change allows use as a plain Connect middleware.